### PR TITLE
allow non default home dirs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,10 @@
 nvm_version: "v0.33.0"
 nvm_node_version: "6.9.5"
 nvm_user: vagrant
-nvm_npm_pkgs: []
+nvm_working_path: "/home/{{ nvm_user }}"
+nvm_dest: "{{ nvm_working_path }}/.nvm"
 
+nvm_npm_pkgs: []
 required_packages:
   - git
   - curl

--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -21,5 +21,11 @@
 
 - include: permission.yml
 
+- name: NVM | nvm | ensure ~/.bashrc exists
+  copy: 
+    content: "" 
+    dest: "{{ nvm_working_path }}/.bashrc" 
+    force: no
+
 - name: NVM | nvm | add nvm to ~/.bashrc
   lineinfile: dest="{{ nvm_working_path }}/.bashrc" line="source ~/.nvm/nvm.sh"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,0 @@
----
-
-nvm_working_path: "/home/{{ nvm_user }}"
-nvm_dest: "{{ nvm_working_path }}/.nvm"


### PR DESCRIPTION
- move nvm_working_path and dest out of vars into defaults
  - This allows you to specify nvm_working_path and nvm_dest from group_vars, host_vars or an external inventory.  Without this, you cannot specify a user that does not have a home directory in /home/ (e.g. /var/lib/jenkins/)
- 	create .bashrc if not existing